### PR TITLE
Typo on .spectral.yml link

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@ function show_error(line, ch) {
 
 This standalone page uses <a href="https://github.com/stoplightio/spectral">Spectral</a> to lint
 an OAS3 specification using the rules defined in
-<a class="navbar-brand py-2 text-decoration-none" href="https://raw.githubusercontent.com/ioggstream/oas-spectral-validator/master/.spectral.yml%22">.spectral.yml</a>
+<a class="navbar-brand py-2 text-decoration-none" href="https://raw.githubusercontent.com/ioggstream/oas-spectral-validator/master/.spectral.yml">.spectral.yml</a>
 <br>
 You can download an OAS spec using the URL linter and
 then edit and lint the specification manually,


### PR DESCRIPTION
There was an unexpected encoded char at the end of the `.spectral.yml` URL